### PR TITLE
I have added some support for the Sync function without talking to mount. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /BresserGoTo_ReverseEngineer/BresserGoTo_ReverseEngineer/obj/Debug
 *.sch-bak
 build
+try
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /BresserGoTo_ReverseEngineer/BresserGoTo_ReverseEngineer/obj/Debug
 *.sch-bak
+build

--- a/BresserExosIIGoToDriver.cpp
+++ b/BresserExosIIGoToDriver.cpp
@@ -293,15 +293,14 @@ bool BresserExosIIDriver::Sync(double ra, double dec)
         return false;
     }
 
+    LOGF_INFO("BresserExosIIDriver::Sync: Syncronizing to Right Ascension: %f Declination :%f...", ra, dec);
+
     //if(!std::isnan(mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension)) {
         mMountControl.mCurrentPointingCoordinatesSyncCorrection.RightAscension=ra-mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension;
     //}
     //if(!std::isnan(mMountControl.mCurrentPointingCoordinatesSyncBase.Declination)) {
         mMountControl.mCurrentPointingCoordinatesSyncCorrection.Declination=dec-mMountControl.mCurrentPointingCoordinatesSyncBase.Declination;
-    //}
-    
-
-    LOGF_INFO("BresserExosIIDriver::Sync: Syncronizing to Right Ascension: %f Declination :%f...", ra, dec);
+    //}    
 
     return mMountControl.Sync((float)ra, (float)dec);
 }
@@ -309,12 +308,12 @@ bool BresserExosIIDriver::Sync(double ra, double dec)
 //Go to the coordinates in the sky, This automatically tracks the selected coordinates.
 bool BresserExosIIDriver::Goto(double ra, double dec)
 {
+    LOGF_INFO("BresserExosIIDriver::Goto: Going to Right Ascension: %f Declination :%f...", ra, dec);
+
     ra = ra - mMountControl.mCurrentPointingCoordinatesSyncCorrection.RightAscension;
     dec = dec - mMountControl.mCurrentPointingCoordinatesSyncCorrection.Declination;
     mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension = ra;
-    mMountControl.mCurrentPointingCoordinatesSyncBase.Declination  = dec;
-
-    LOGF_INFO("BresserExosIIDriver::Goto: Going to Right Ascension: %f Declination :%f...", ra, dec);
+    mMountControl.mCurrentPointingCoordinatesSyncBase.Declination  = dec;    
 
     return mMountControl.GoTo((float)ra, (float)dec);
 }

--- a/BresserExosIIGoToDriver.cpp
+++ b/BresserExosIIGoToDriver.cpp
@@ -154,11 +154,8 @@ bool BresserExosIIDriver::Connect()
 
     //this message reports back the site location, also starts position reports, without changing anything on the scope.
     mMountControl.RequestSiteLocation();
-    
-    mMountControl.mCurrentPointingCoordinatesSyncCorrection.RightAscension=0.;
-    mMountControl.mCurrentPointingCoordinatesSyncCorrection.Declination=0.;
-    mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension=0.;
-    mMountControl.mCurrentPointingCoordinatesSyncBase.Declination=0.;
+
+    mMountControl.ResetCurrentCoordinatesSyncCorrection();
 
     IEAddTimer(DRIVER_WATCHDOG_TIMEOUT, DriverWatchDog, this);
 
@@ -302,11 +299,6 @@ bool BresserExosIIDriver::Sync(double ra, double dec)
 bool BresserExosIIDriver::Goto(double ra, double dec)
 {
     LOGF_INFO("BresserExosIIDriver::Goto: Going to Right Ascension: %f Declination :%f...", ra, dec);
-
-    ra = ra - mMountControl.mCurrentPointingCoordinatesSyncCorrection.RightAscension;
-    dec = dec - mMountControl.mCurrentPointingCoordinatesSyncCorrection.Declination;
-    mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension = ra;
-    mMountControl.mCurrentPointingCoordinatesSyncBase.Declination  = dec;    
 
     return mMountControl.GoTo((float)ra, (float)dec);
 }

--- a/BresserExosIIGoToDriver.cpp
+++ b/BresserExosIIGoToDriver.cpp
@@ -35,52 +35,11 @@
 using namespace GoToDriver;
 using namespace SerialDeviceControl;
 
-#if INDI_LEGACY_ENABLED
-//This is required if you compile the driver for libindi versions below 1.90, whereafter a different driver linking approach is used.
-static std::unique_ptr<BresserExosIIDriver> driver_instance(new BresserExosIIDriver());
-
-void ISGetProperties(const char* dev)
-{
-    driver_instance->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char* dev, const char* name, ISState * states, char* names[], int n)
-{
-    driver_instance->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    driver_instance->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    driver_instance->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char* dev, const char* name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    INDI_UNUSED(dev);
-    INDI_UNUSED(name);
-    INDI_UNUSED(sizes);
-    INDI_UNUSED(blobsizes);
-    INDI_UNUSED(blobs);
-    INDI_UNUSED(formats);
-    INDI_UNUSED(names);
-    INDI_UNUSED(n);
-}
-
-void ISSnoopDevice(XMLEle* root)
-{
-    driver_instance->ISSnoopDevice(root);
-}
-#endif
+static std::unique_ptr<BresserExosIIDriver> mount(new BresserExosIIDriver());
 
 //default constructor.
 //sets the scope abilities, and default settings.
-BresserExosIIDriver::BresserExosIIDriver() :
+BresserExosIIDriver::BresserExosIIDriver() : GI(this),
     mInterfaceWrapper(),
     mMountControl(mInterfaceWrapper)
 {
@@ -91,11 +50,11 @@ BresserExosIIDriver::BresserExosIIDriver() :
     SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_ABORT |
                            TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION, 0);
 
-	mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
-	mGuideStateNS.remaining_messages = 0;
-	
-	mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
-	mGuideStateEW.remaining_messages = 0;
+    mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
+    mGuideStateNS.remaining_messages = 0;
+
+    mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
+    mGuideStateEW.remaining_messages = 0;
 
     setDefaultPollingPeriod(500);
 }
@@ -111,24 +70,22 @@ bool BresserExosIIDriver::initProperties()
 {
     INDI::Telescope::initProperties();
 
-    initGuiderProperties(getDeviceName(), MOTION_TAB);
+    GI::initProperties(MOTION_TAB);
 
     setTelescopeConnection(CONNECTION_SERIAL);
 
     addDebugControl();
-    
-	IUFillText(&SourceCodeRepositoryURLT[0], "REPOSITORY_URL", "Code Repository", "https://github.com/kneo/indi-bresserexos2");
-	
-    IUFillTextVector(&SourceCodeRepositoryURLTP, SourceCodeRepositoryURLT, 1, getDeviceName(), "REPOSITORY_URL", "Source Code", CONNECTION_TAB, IP_RO, 0, IPS_IDLE);
-	
-	defineProperty(&SourceCodeRepositoryURLTP);
-    
+
+    IUFillText(&SourceCodeRepositoryURLT[0], "REPOSITORY_URL", "Code Repository", "https://github.com/kneo/indi-bresserexos2");
+
+    IUFillTextVector(&SourceCodeRepositoryURLTP, SourceCodeRepositoryURLT, 1, getDeviceName(), "REPOSITORY_URL", "Source Code",
+                     CONNECTION_TAB, IP_RO, 0, IPS_IDLE);
+
+    defineProperty(&SourceCodeRepositoryURLTP);
+
     SetParkDataType(PARK_NONE);
 
     TrackState = SCOPE_IDLE;
-     
-    defineProperty(&GuideNSNP);
-    defineProperty(&GuideWENP);
 
     addAuxControls();
 
@@ -141,6 +98,7 @@ bool BresserExosIIDriver::initProperties()
 bool BresserExosIIDriver::updateProperties()
 {
     bool rc = INDI::Telescope::updateProperties();
+    GI::updateProperties();
 
     return rc;
 }
@@ -156,7 +114,7 @@ bool BresserExosIIDriver::Connect()
     mMountControl.RequestSiteLocation();
 
     mMountControl.ResetCurrentCoordinatesSyncCorrection();
-
+    
     IEAddTimer(DRIVER_WATCHDOG_TIMEOUT, DriverWatchDog, this);
 
     return rc;
@@ -247,15 +205,10 @@ bool BresserExosIIDriver::ReadScopeStatus()
 
 bool BresserExosIIDriver::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
 {
-    if (!strcmp(dev, getDeviceName()))
-	{
-		if (!strcmp(name, GuideNSNP.name) || !strcmp(name, GuideWENP.name))
-		{
-		    processGuiderProperties(name, values, names, n);
-		    return true;
-		}
-	}
-    
+    // Check guider interface
+    if (GI::processNumber(dev, name, values, names, n))
+        return true;
+
     return INDI::Telescope::ISNewNumber(dev, name, values, names, n);
 }
 
@@ -286,11 +239,11 @@ bool BresserExosIIDriver::Sync(double ra, double dec)
 {
     if(TrackState != SCOPE_TRACKING)
     {
-        LOG_INFO("BresserExosIIDriver::Sync: Unable to Syncronize! This function only works when tracking a sky object!");
+        LOG_INFO("BresserExosIIDriver::Sync: Unable to Synchronize! This function only works when tracking a sky object!");
         return false;
     }
 
-    LOGF_INFO("BresserExosIIDriver::Sync: Syncronizing to Right Ascension: %f Declination :%f...", ra, dec);
+    LOGF_INFO("BresserExosIIDriver::Sync: Synchronizing to Right Ascension: %f Declination :%f...", ra, dec);
 
     return mMountControl.Sync((float)ra, (float)dec);
 }
@@ -307,8 +260,8 @@ bool BresserExosIIDriver::Goto(double ra, double dec)
 bool BresserExosIIDriver::Abort()
 {
     LOG_INFO("BresserExosIIDriver::Abort: motion stopped!");
-    
-	if (GuideNSTID)
+
+    if (GuideNSTID)
     {
         IERmTimer(GuideNSTID);
         GuideNSTID = 0;
@@ -319,10 +272,10 @@ bool BresserExosIIDriver::Abort()
         IERmTimer(GuideWETID);
         GuideNSTID = 0;
     }
-	
-	IDSetNumber(&GuideNSNP, nullptr);
-    IDSetNumber(&GuideWENP, nullptr);
-        
+
+    GuideNSNP.apply();
+    GuideWENP.apply();
+
     return mMountControl.StopMotion();
 }
 
@@ -350,7 +303,7 @@ bool BresserExosIIDriver::updateTime(ln_date *utc, double utc_offset)
     // Bresser takes local time and DST but ln_zonedate doesn't have DST
     struct ln_zonedate local_date;
     ln_date_to_zonedate(utc, &local_date, static_cast<int>(utc_offset * 3600));
-    
+
     uint16_t years = (uint16_t)local_date.years;
     uint8_t months = (uint8_t)local_date.months;
     uint8_t days =   (uint8_t)local_date.days;
@@ -360,27 +313,28 @@ bool BresserExosIIDriver::updateTime(ln_date *utc, double utc_offset)
     uint8_t seconds = (uint8_t) local_date.seconds;
     int8_t utc_off = (int8_t) utc_offset;
 
-    LOGF_INFO("Date/Time updated (UTC Time): %d:%d:%d %d-%d-%d (%d)", utc->hours, utc->minutes, utc->seconds, utc->years, utc->months, utc->days, utc_off);
+    LOGF_INFO("Date/Time updated (UTC Time): %d:%d:%d %d-%d-%d (%d)", utc->hours, utc->minutes, utc->seconds, utc->years,
+              utc->months, utc->days, utc_off);
     LOGF_INFO("Date/Time updated (Local Time): %d:%d:%d %d-%d-%d (%d)", hours, minutes, seconds, years, months, days, utc_off);
 
-    return mMountControl.SetDateTime(years, months, days, hours, minutes, seconds,utc_off);
+    return mMountControl.SetDateTime(years, months, days, hours, minutes, seconds, utc_off);
 }
 
 //update the location of the scope.
 bool BresserExosIIDriver::updateLocation(double latitude, double longitude, double elevation)
 {
     INDI_UNUSED(elevation);
-    
-    //orientation of the handbox is: 
+
+    //orientation of the handbox is:
     //negative longitude is west of greenich
     //positive longitude is east of greenich
     //kstars sends 360 complements for negatives
     //this sole case needs to be corrected:
     double realLongitude = longitude;
-    
-    if(realLongitude>180)
+
+    if(realLongitude > 180)
     {
-	realLongitude -= 360;
+        realLongitude -= 360;
     }
 
     LOGF_INFO("Location updated: Longitude (%g) Latitude (%g)", realLongitude, latitude);
@@ -477,7 +431,7 @@ bool BresserExosIIDriver::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command
 
 //amount of degree change per "pulse command" -> tracking speeds can be set in the HBX,
 //it states 1x -> 0.125 * star speed (0.0041°/s ^= 15"/s) and goes up to 8x -> 1.00 * star speed, which would advance by on second, thus guiding speeds are user dependent.
-//amount of time necessary to transmit a message -> 12.1 ms 
+//amount of time necessary to transmit a message -> 12.1 ms
 //(9600 baud / 8 -> 1200, but deminished by the stop bit yielding a net data rate of around 1067 byte/s)
 //allows around 82 messages send to the mount per second.
 //Assume half if serial transmission is not full duplex capable.
@@ -486,147 +440,147 @@ bool BresserExosIIDriver::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command
 //double these amounts if full duplex is possible.
 IPState BresserExosIIDriver::GuideNorth(uint32_t ms)
 {
-	//LOGF_INFO("BresserExosIIDriver::GuideNorth: guiding %d ms", ms);
-	
-	if(mMountControl.GetTelescopeState() == TelescopeMountControl::TelescopeMountState::MoveWhileTracking)
-	{
-		LOG_INFO("BresserExosIIDriver::GuideNorth: motion while tracking stopped!");
-		mMountControl.StopMotionToDirection();
-	}
-	
-	uint32_t messages = ms / GUIDE_TIMEOUT;
-	
+    //LOGF_INFO("BresserExosIIDriver::GuideNorth: guiding %d ms", ms);
+
+    if(mMountControl.GetTelescopeState() == TelescopeMountControl::TelescopeMountState::MoveWhileTracking)
+    {
+        LOG_INFO("BresserExosIIDriver::GuideNorth: motion while tracking stopped!");
+        mMountControl.StopMotionToDirection();
+    }
+
+    uint32_t messages = ms / GUIDE_TIMEOUT;
+
     LOGF_INFO("BresserExosIIDriver::GuideNord: guiding %d ms (%d messages)", ms, messages);
-    
-	if (GuideNSTID) //reset timer if any.
-	{
-		IERmTimer(GuideNSTID);
-		GuideNSTID = 0;
-	}
-	
-	if(messages>0)
-	{
-		mMountControl.GuideNorth(); // send one pulse
-		messages--;
-		
-		mGuideStateNS.remaining_messages = messages;
-		mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::MOVE_NORTH_COMMAND_ID;
-		
-		GuideNSTID = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperN, this); //wait for nex pulse if any.
-		
-		return IPS_BUSY;
-	}
-	
-	return IPS_IDLE;
+
+    if (GuideNSTID) //reset timer if any.
+    {
+        IERmTimer(GuideNSTID);
+        GuideNSTID = 0;
+    }
+
+    if(messages > 0)
+    {
+        mMountControl.GuideNorth(); // send one pulse
+        messages--;
+
+        mGuideStateNS.remaining_messages = messages;
+        mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::MOVE_NORTH_COMMAND_ID;
+
+        GuideNSTID = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperN, this); //wait for nex pulse if any.
+
+        return IPS_BUSY;
+    }
+
+    return IPS_IDLE;
 }
 
 IPState BresserExosIIDriver::GuideSouth(uint32_t ms)
 {
-	//LOGF_INFO("BresserExosIIDriver::GuideSouth: guiding %d ms", ms);
-	
-	if(mMountControl.GetTelescopeState() == TelescopeMountControl::TelescopeMountState::MoveWhileTracking)
-	{
-		LOG_INFO("BresserExosIIDriver::GuideNorth: motion while tracking stopped!");
-		mMountControl.StopMotionToDirection();
-	}
-	
-	uint32_t messages = ms / GUIDE_TIMEOUT;
-    
+    //LOGF_INFO("BresserExosIIDriver::GuideSouth: guiding %d ms", ms);
+
+    if(mMountControl.GetTelescopeState() == TelescopeMountControl::TelescopeMountState::MoveWhileTracking)
+    {
+        LOG_INFO("BresserExosIIDriver::GuideNorth: motion while tracking stopped!");
+        mMountControl.StopMotionToDirection();
+    }
+
+    uint32_t messages = ms / GUIDE_TIMEOUT;
+
     LOGF_INFO("BresserExosIIDriver::GuideSouth: guiding %d ms (%d messages)", ms, messages);
-	
-	if (GuideNSTID) //reset timer if any.
-	{
-		IERmTimer(GuideNSTID);
-		GuideNSTID = 0;
-	}
-	
-	if(messages>0)
-	{
-		mMountControl.GuideSouth(); // send one pulse
-		messages--;
-		
-		mGuideStateNS.remaining_messages = messages;
-		mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::MOVE_SOUTH_COMMAND_ID;
-		
-		GuideNSTID = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperS, this); //wait for nex pulse if any.
-		
-		return IPS_BUSY;
-	}
-	
-	return IPS_IDLE;
+
+    if (GuideNSTID) //reset timer if any.
+    {
+        IERmTimer(GuideNSTID);
+        GuideNSTID = 0;
+    }
+
+    if(messages > 0)
+    {
+        mMountControl.GuideSouth(); // send one pulse
+        messages--;
+
+        mGuideStateNS.remaining_messages = messages;
+        mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::MOVE_SOUTH_COMMAND_ID;
+
+        GuideNSTID = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperS, this); //wait for nex pulse if any.
+
+        return IPS_BUSY;
+    }
+
+    return IPS_IDLE;
 }
 
 IPState BresserExosIIDriver::GuideEast(uint32_t ms)
 {
-	//LOGF_INFO("BresserExosIIDriver::GuideEast: guiding %d ms", ms);
-	
-	if(mMountControl.GetTelescopeState() == TelescopeMountControl::TelescopeMountState::MoveWhileTracking)
-	{
-		LOG_INFO("BresserExosIIDriver::GuideNorth: motion while tracking stopped!");
-		mMountControl.StopMotionToDirection();
-	}
-	
-	uint32_t messages = ms / GUIDE_TIMEOUT;
-    
+    //LOGF_INFO("BresserExosIIDriver::GuideEast: guiding %d ms", ms);
+
+    if(mMountControl.GetTelescopeState() == TelescopeMountControl::TelescopeMountState::MoveWhileTracking)
+    {
+        LOG_INFO("BresserExosIIDriver::GuideNorth: motion while tracking stopped!");
+        mMountControl.StopMotionToDirection();
+    }
+
+    uint32_t messages = ms / GUIDE_TIMEOUT;
+
     LOGF_INFO("BresserExosIIDriver::GuideEast: guiding %d ms (%d messages)", ms, messages);
-	
-	if (GuideWETID) //reset timer if any.
-	{
-		IERmTimer(GuideWETID);
-		GuideWETID = 0;
-	}
-	
-	if(messages>0)
-	{
-		mMountControl.GuideEast(); // send one pulse
-		
-		messages--;
-		
-		mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::MOVE_EAST_COMMAND_ID;
-		mGuideStateEW.remaining_messages = messages;
-		
-		GuideWETID = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperE, this); //wait for nex pulse if any.
-		
-		return IPS_BUSY;
-	}
-	
-	return IPS_IDLE;
+
+    if (GuideWETID) //reset timer if any.
+    {
+        IERmTimer(GuideWETID);
+        GuideWETID = 0;
+    }
+
+    if(messages > 0)
+    {
+        mMountControl.GuideEast(); // send one pulse
+
+        messages--;
+
+        mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::MOVE_EAST_COMMAND_ID;
+        mGuideStateEW.remaining_messages = messages;
+
+        GuideWETID = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperE, this); //wait for nex pulse if any.
+
+        return IPS_BUSY;
+    }
+
+    return IPS_IDLE;
 }
 
 IPState BresserExosIIDriver::GuideWest(uint32_t ms)
 {
-	//LOGF_INFO("BresserExosIIDriver::GuideWest: guiding %d ms", ms);
-	
-	if(mMountControl.GetTelescopeState() == TelescopeMountControl::TelescopeMountState::MoveWhileTracking)
-	{
-		LOG_INFO("BresserExosIIDriver::GuideNorth: motion while tracking stopped!");
-		mMountControl.StopMotionToDirection();
-	}
-	
-	uint32_t messages = ms / GUIDE_TIMEOUT;
-    
+    //LOGF_INFO("BresserExosIIDriver::GuideWest: guiding %d ms", ms);
+
+    if(mMountControl.GetTelescopeState() == TelescopeMountControl::TelescopeMountState::MoveWhileTracking)
+    {
+        LOG_INFO("BresserExosIIDriver::GuideNorth: motion while tracking stopped!");
+        mMountControl.StopMotionToDirection();
+    }
+
+    uint32_t messages = ms / GUIDE_TIMEOUT;
+
     LOGF_INFO("BresserExosIIDriver::GuideWest: guiding %d ms (%d messages)", ms, messages);
-	
-	if (GuideWETID) //reset timer if any.
-	{
-		IERmTimer(GuideWETID);
-		GuideWETID = 0;
-	}
-	
-	if(messages>0)
-	{
-		mMountControl.GuideWest();
-		 
-		messages--;
-		mGuideStateEW.remaining_messages = messages;
-		mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::MOVE_WEST_COMMAND_ID;
-		
-		GuideWETID = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperW, this); //wait for nex pulse if any.
-		
-		return IPS_BUSY;
-	}
-	
-	return IPS_IDLE;
+
+    if (GuideWETID) //reset timer if any.
+    {
+        IERmTimer(GuideWETID);
+        GuideWETID = 0;
+    }
+
+    if(messages > 0)
+    {
+        mMountControl.GuideWest();
+
+        messages--;
+        mGuideStateEW.remaining_messages = messages;
+        mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::MOVE_WEST_COMMAND_ID;
+
+        GuideWETID = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperW, this); //wait for nex pulse if any.
+
+        return IPS_BUSY;
+    }
+
+    return IPS_IDLE;
 }
 
 void BresserExosIIDriver::DriverWatchDog(void *p)
@@ -651,99 +605,99 @@ void BresserExosIIDriver::DriverWatchDog(void *p)
 
 void BresserExosIIDriver::guideTimeout(SerialDeviceControl::SerialCommandID direction)
 {
-	bool continuePulsing = false;
-	switch(direction)
-	{
-		case SerialDeviceControl::SerialCommandID::MOVE_NORTH_COMMAND_ID:
-			continuePulsing = mGuideStateNS.remaining_messages > 0;
-			
-			if(continuePulsing)
-			{
-				mGuideStateNS.remaining_messages--;
-				mMountControl.GuideNorth();
-				GuideNSNP.s = IPS_BUSY;
-				GuideNSTID  = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperN, this); 
-			}
-			else
-			{
-				GuideNSNP.s = IPS_IDLE;
-				GuideNSTID=0;
-				mGuideStateNS.remaining_messages = 0;
-				mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
-				IDSetNumber(&GuideNSNP, nullptr);
-			}
-		break;
-		
-		case SerialDeviceControl::SerialCommandID::MOVE_SOUTH_COMMAND_ID:
-			continuePulsing = mGuideStateNS.remaining_messages > 0;
-			
-			if(continuePulsing)
-			{
-				mGuideStateNS.remaining_messages--;
-				mMountControl.GuideSouth();
-				GuideNSNP.s = IPS_BUSY;
-				GuideNSTID  = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperS, this);
-			}
-			else
-			{
-				GuideNSNP.s = IPS_IDLE;
-				GuideNSTID=0;
-				mGuideStateNS.remaining_messages = 0;
-				mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
-				IDSetNumber(&GuideNSNP, nullptr);
-			}
-		break;
-		
-		case SerialDeviceControl::SerialCommandID::MOVE_WEST_COMMAND_ID:
-			continuePulsing = mGuideStateEW.remaining_messages > 0;
-			
-			if(continuePulsing)
-			{
-				mGuideStateEW.remaining_messages--;
-				mMountControl.GuideWest();
-				GuideWENP.s = IPS_BUSY;
-				GuideNSTID  = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperW, this);
-			}
-			else
-			{
-				GuideWENP.s = IPS_IDLE;
-				GuideWETID=0;
-				mGuideStateEW.remaining_messages = 0;
-				mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
-				IDSetNumber(&GuideWENP, nullptr);
-			}
-		break;
+    bool continuePulsing = false;
+    switch(direction)
+    {
+        case SerialDeviceControl::SerialCommandID::MOVE_NORTH_COMMAND_ID:
+            continuePulsing = mGuideStateNS.remaining_messages > 0;
 
-		case SerialDeviceControl::SerialCommandID::MOVE_EAST_COMMAND_ID:
-			continuePulsing = mGuideStateEW.remaining_messages > 0;
-					
-			if(continuePulsing)
-			{
-				mGuideStateEW.remaining_messages--;
-				mMountControl.GuideEast();
-				GuideWENP.s = IPS_BUSY;
-				GuideNSTID  = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperE, this); 
-			}
-			else
-			{
-				GuideWENP.s = IPS_IDLE;
-				GuideWETID=0;
-				mGuideStateEW.remaining_messages = 0;
-				mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
-				IDSetNumber(&GuideWENP, nullptr);
-			}
-		break;
-		
-		default:
-			GuideWENP.s = IPS_IDLE;
-			GuideWETID=0;
-			IDSetNumber(&GuideWENP, nullptr);
-			
-			GuideNSNP.s = IPS_IDLE;
-			GuideNSTID=0;
-			IDSetNumber(&GuideNSNP, nullptr);
-		break;
-	}
+            if(continuePulsing)
+            {
+                mGuideStateNS.remaining_messages--;
+                mMountControl.GuideNorth();
+                GuideNSNP.setState(IPS_BUSY);
+                GuideNSTID  = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperN, this);
+            }
+            else
+            {
+                GuideNSNP.setState(IPS_IDLE);
+                GuideNSTID = 0;
+                mGuideStateNS.remaining_messages = 0;
+                mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
+                GuideNSNP.apply();
+            }
+            break;
+
+        case SerialDeviceControl::SerialCommandID::MOVE_SOUTH_COMMAND_ID:
+            continuePulsing = mGuideStateNS.remaining_messages > 0;
+
+            if(continuePulsing)
+            {
+                mGuideStateNS.remaining_messages--;
+                mMountControl.GuideSouth();
+                GuideNSNP.setState(IPS_BUSY);
+                GuideNSTID  = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperS, this);
+            }
+            else
+            {
+                GuideNSNP.setState(IPS_IDLE);
+                GuideNSTID = 0;
+                mGuideStateNS.remaining_messages = 0;
+                mGuideStateNS.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
+                GuideNSNP.apply();
+            }
+            break;
+
+        case SerialDeviceControl::SerialCommandID::MOVE_WEST_COMMAND_ID:
+            continuePulsing = mGuideStateEW.remaining_messages > 0;
+
+            if(continuePulsing)
+            {
+                mGuideStateEW.remaining_messages--;
+                mMountControl.GuideWest();
+                GuideWENP.setState(IPS_BUSY);
+                GuideNSTID  = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperW, this);
+            }
+            else
+            {
+                GuideWENP.setState(IPS_IDLE);
+                GuideWETID = 0;
+                mGuideStateEW.remaining_messages = 0;
+                mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
+                GuideWENP.apply();
+            }
+            break;
+
+        case SerialDeviceControl::SerialCommandID::MOVE_EAST_COMMAND_ID:
+            continuePulsing = mGuideStateEW.remaining_messages > 0;
+
+            if(continuePulsing)
+            {
+                mGuideStateEW.remaining_messages--;
+                mMountControl.GuideEast();
+                GuideWENP.setState(IPS_BUSY);
+                GuideNSTID  = IEAddTimer(GUIDE_TIMEOUT, guideTimeoutHelperE, this);
+            }
+            else
+            {
+                GuideWENP.setState(IPS_IDLE);
+                GuideWETID = 0;
+                mGuideStateEW.remaining_messages = 0;
+                mGuideStateEW.direction = SerialDeviceControl::SerialCommandID::NULL_COMMAND_ID;
+                GuideWENP.apply();
+            }
+            break;
+
+        default:
+            GuideWENP.setState(IPS_IDLE);
+            GuideWETID = 0;
+            GuideWENP.apply();
+
+            GuideNSNP.setState(IPS_IDLE);
+            GuideNSTID = 0;
+            GuideNSNP.apply();
+            break;
+    }
 }
 
 //GUIDE The timer helper functions.
@@ -754,7 +708,7 @@ void BresserExosIIDriver::guideTimeoutHelperN(void *p)
 
 void BresserExosIIDriver::guideTimeoutHelperS(void *p)
 {
-   static_cast<BresserExosIIDriver*>(p)->guideTimeout(SerialDeviceControl::SerialCommandID::MOVE_SOUTH_COMMAND_ID);
+    static_cast<BresserExosIIDriver*>(p)->guideTimeout(SerialDeviceControl::SerialCommandID::MOVE_SOUTH_COMMAND_ID);
 }
 
 void BresserExosIIDriver::guideTimeoutHelperW(void *p)

--- a/BresserExosIIGoToDriver.cpp
+++ b/BresserExosIIGoToDriver.cpp
@@ -295,13 +295,6 @@ bool BresserExosIIDriver::Sync(double ra, double dec)
 
     LOGF_INFO("BresserExosIIDriver::Sync: Syncronizing to Right Ascension: %f Declination :%f...", ra, dec);
 
-    //if(!std::isnan(mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension)) {
-        mMountControl.mCurrentPointingCoordinatesSyncCorrection.RightAscension=ra-mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension;
-    //}
-    //if(!std::isnan(mMountControl.mCurrentPointingCoordinatesSyncBase.Declination)) {
-        mMountControl.mCurrentPointingCoordinatesSyncCorrection.Declination=dec-mMountControl.mCurrentPointingCoordinatesSyncBase.Declination;
-    //}    
-
     return mMountControl.Sync((float)ra, (float)dec);
 }
 

--- a/BresserExosIIGoToDriver.cpp
+++ b/BresserExosIIGoToDriver.cpp
@@ -154,6 +154,11 @@ bool BresserExosIIDriver::Connect()
 
     //this message reports back the site location, also starts position reports, without changing anything on the scope.
     mMountControl.RequestSiteLocation();
+    
+    mMountControl.mCurrentPointingCoordinatesSyncCorrection.RightAscension=0.;
+    mMountControl.mCurrentPointingCoordinatesSyncCorrection.Declination=0.;
+    mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension=0.;
+    mMountControl.mCurrentPointingCoordinatesSyncBase.Declination=0.;
 
     IEAddTimer(DRIVER_WATCHDOG_TIMEOUT, DriverWatchDog, this);
 
@@ -288,6 +293,14 @@ bool BresserExosIIDriver::Sync(double ra, double dec)
         return false;
     }
 
+    //if(!std::isnan(mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension)) {
+        mMountControl.mCurrentPointingCoordinatesSyncCorrection.RightAscension=ra-mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension;
+    //}
+    //if(!std::isnan(mMountControl.mCurrentPointingCoordinatesSyncBase.Declination)) {
+        mMountControl.mCurrentPointingCoordinatesSyncCorrection.Declination=dec-mMountControl.mCurrentPointingCoordinatesSyncBase.Declination;
+    //}
+    
+
     LOGF_INFO("BresserExosIIDriver::Sync: Syncronizing to Right Ascension: %f Declination :%f...", ra, dec);
 
     return mMountControl.Sync((float)ra, (float)dec);
@@ -296,6 +309,11 @@ bool BresserExosIIDriver::Sync(double ra, double dec)
 //Go to the coordinates in the sky, This automatically tracks the selected coordinates.
 bool BresserExosIIDriver::Goto(double ra, double dec)
 {
+    ra = ra - mMountControl.mCurrentPointingCoordinatesSyncCorrection.RightAscension;
+    dec = dec - mMountControl.mCurrentPointingCoordinatesSyncCorrection.Declination;
+    mMountControl.mCurrentPointingCoordinatesSyncBase.RightAscension = ra;
+    mMountControl.mCurrentPointingCoordinatesSyncBase.Declination  = dec;
+
     LOGF_INFO("BresserExosIIDriver::Goto: Going to Right Ascension: %f Declination :%f...", ra, dec);
 
     return mMountControl.GoTo((float)ra, (float)dec);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.0)
-project(indi-bresserexos2 VERSION 0.951)
+cmake_minimum_required(VERSION 3.16)
+project(indi-bresserexos2 VERSION 0.952)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/")
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(indi-bresserexos2 VERSION 0.904)
+project(indi-bresserexos2 VERSION 9.999)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/")
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(indi-bresserexos2 VERSION 0.950)
+project(indi-bresserexos2 VERSION 0.951)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/")
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(indi-bresserexos2 VERSION 9.999)
+project(indi-bresserexos2 VERSION 0.950)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/")
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(indi-bresserexos2 VERSION 0.901)
+project(indi-bresserexos2 VERSION 0.904)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/")
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -445,7 +445,8 @@ class ExosIIMountControl :
             std::vector<uint8_t> messageBuffer;
             if(SerialDeviceControl::SerialCommand::GetSyncCommandMessage(messageBuffer, rightAscension, declination))
             {                
-                if (true) {  
+
+                    // Talking to coordinates correction inside driver without talking to mount
                     std::cerr << "Sent Sync command to coordinates correction!" << std::endl;   
                     SerialDeviceControl::EquatorialCoordinates tmpSyncBaseCoordinates;
                     SerialDeviceControl::EquatorialCoordinates tmpSyncCorrCoordinates;
@@ -464,13 +465,13 @@ class ExosIIMountControl :
                     }
                     mCurrentPointingCoordinatesSyncCorrection.Set(tmpSyncCorrCoordinates);
                     return true;
-                }             
-                else {
-                    std::cerr << "Sent Sync command to mount!" << std::endl;       
-                    return SerialDeviceControl::SerialCommandTransceiver<InterfaceType, TelescopeMountControl::ExosIIMountControl<InterfaceType>>::SendMessageBuffer(
-                            &messageBuffer[0], 0, messageBuffer.size());
-                    //return rc && mMountStateMachine.DoTransition(TelescopeSignals::GoTo);
-                }
+
+                    // // Talking to mount
+                    // std::cerr << "Sent Sync command to mount!" << std::endl;       
+                    // return SerialDeviceControl::SerialCommandTransceiver<InterfaceType, TelescopeMountControl::ExosIIMountControl<InterfaceType>>::SendMessageBuffer(
+                    //         &messageBuffer[0], 0, messageBuffer.size());
+                    // //return rc && mMountStateMachine.DoTransition(TelescopeSignals::GoTo);
+
             }
             else
             {
@@ -719,12 +720,9 @@ class ExosIIMountControl :
                         else
                         {
                             // align Sync Base while tracking: motions occurred, mount tracking not perfect, guiding motions
-                            SerialDeviceControl::EquatorialCoordinates tmpSyncBaseCoordinates; 
-                            SerialDeviceControl::EquatorialCoordinates tmpSyncCorrCoordinates; 
-                            SerialDeviceControl::EquatorialCoordinates ec = mCurrentPointingCoordinates.Get(); 
-                            tmpSyncCorrCoordinates = mCurrentPointingCoordinatesSyncCorrection.Get();                           
-                            tmpSyncBaseCoordinates.RightAscension = ec.RightAscension - tmpSyncCorrCoordinates.RightAscension;
-                            tmpSyncBaseCoordinates.Declination = ec.Declination - tmpSyncCorrCoordinates.Declination;
+                            SerialDeviceControl::EquatorialCoordinates tmpSyncBaseCoordinates;                            
+                            tmpSyncBaseCoordinates.RightAscension = right_ascension;
+                            tmpSyncBaseCoordinates.Declination = declination;
                             mCurrentPointingCoordinatesSyncBase.Set(tmpSyncBaseCoordinates);
 
                             signal = TelescopeSignals::Track;

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -290,8 +290,8 @@ class ExosIIMountControl :
         {
             mCurrentPointingCoordinatesSyncCorrection.RightAscension = 0.;
             mCurrentPointingCoordinatesSyncCorrection.Declination = 0.;
-            mCurrentPointingCoordinatesSyncBase.RightAscension = 0.;
-            mCurrentPointingCoordinatesSyncBase.Declination = 0.;
+            mCurrentPointingCoordinatesSyncBase.RightAscension = std::numeric_limits<float>::quiet_NaN();;
+            mCurrentPointingCoordinatesSyncBase.Declination = std::numeric_limits<float>::quiet_NaN();
         }
 
 
@@ -435,10 +435,20 @@ class ExosIIMountControl :
             std::vector<uint8_t> messageBuffer;
             if(SerialDeviceControl::SerialCommand::GetSyncCommandMessage(messageBuffer, rightAscension, declination))
             {                
-                if (true) {
-                    std::cerr << "Sent Sync command to coordinates correction!" << std::endl;       
-                    mCurrentPointingCoordinatesSyncCorrection.RightAscension=rightAscension-mCurrentPointingCoordinatesSyncBase.RightAscension;        
-                    mCurrentPointingCoordinatesSyncCorrection.Declination=declination-mCurrentPointingCoordinatesSyncBase.Declination;        
+                if (true) {  
+                    std::cerr << "Sent Sync command to coordinates correction!" << std::endl;                           
+                    if (std::isnan(mCurrentPointingCoordinatesSyncBase.RightAscension)) {
+                        mCurrentPointingCoordinatesSyncCorrection.RightAscension =0. ;
+                    }   
+                    else {
+                        mCurrentPointingCoordinatesSyncCorrection.RightAscension = rightAscension - mCurrentPointingCoordinatesSyncBase.RightAscension;    
+                    } 
+                    if (std::isnan(mCurrentPointingCoordinatesSyncBase.Declination)) {
+                        mCurrentPointingCoordinatesSyncCorrection.Declination = 0.;
+                    }
+                    else {
+                        mCurrentPointingCoordinatesSyncCorrection.Declination = declination - mCurrentPointingCoordinatesSyncBase.Declination;
+                    }
                     return true;
                 }             
                 else {
@@ -605,6 +615,7 @@ class ExosIIMountControl :
             SerialDeviceControl::EquatorialCoordinates lastCoordinates = GetPointingCoordinates();
 
             SerialDeviceControl::EquatorialCoordinates coordinatesReceived;
+
             coordinatesReceived.RightAscension = right_ascension + mCurrentPointingCoordinatesSyncCorrection.RightAscension;
             coordinatesReceived.Declination = declination + mCurrentPointingCoordinatesSyncCorrection.Declination;
 

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -702,7 +702,7 @@ class ExosIIMountControl :
                         }
                         else
                         {
-                            // align Sync Base while tracking: motions occurred, mount tracking not perfect
+                            // align Sync Base while tracking: motions occurred, mount tracking not perfect, guiding motions
                             SerialDeviceControl::EquatorialCoordinates ec = mCurrentPointingCoordinates.Get();
                             mCurrentPointingCoordinatesSyncBase.RightAscension = ec.RightAscension - mCurrentPointingCoordinatesSyncCorrection.RightAscension;
                             mCurrentPointingCoordinatesSyncBase.Declination = ec.Declination - mCurrentPointingCoordinatesSyncCorrection.Declination;

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -426,7 +426,9 @@ class ExosIIMountControl :
             std::vector<uint8_t> messageBuffer;
             if(SerialDeviceControl::SerialCommand::GetSyncCommandMessage(messageBuffer, rightAscension, declination))
             {
-                std::cerr << "Sent Sync command!" << std::endl;
+                std::cerr << "Sent Sync command!" << std::endl;                    
+                mCurrentPointingCoordinatesSyncCorrection.RightAscension=rightAscension-mCurrentPointingCoordinatesSyncBase.RightAscension;        
+                mCurrentPointingCoordinatesSyncCorrection.Declination=declination-mCurrentPointingCoordinatesSyncBase.Declination;        
                 return SerialDeviceControl::SerialCommandTransceiver<InterfaceType, TelescopeMountControl::ExosIIMountControl<InterfaceType>>::SendMessageBuffer(
                            &messageBuffer[0], 0, messageBuffer.size());
                 //return rc && mMountStateMachine.DoTransition(TelescopeSignals::GoTo);

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -426,12 +426,17 @@ class ExosIIMountControl :
             std::vector<uint8_t> messageBuffer;
             if(SerialDeviceControl::SerialCommand::GetSyncCommandMessage(messageBuffer, rightAscension, declination))
             {
-                std::cerr << "Sent Sync command!" << std::endl;                    
-                mCurrentPointingCoordinatesSyncCorrection.RightAscension=rightAscension-mCurrentPointingCoordinatesSyncBase.RightAscension;        
-                mCurrentPointingCoordinatesSyncCorrection.Declination=declination-mCurrentPointingCoordinatesSyncBase.Declination;        
-                return SerialDeviceControl::SerialCommandTransceiver<InterfaceType, TelescopeMountControl::ExosIIMountControl<InterfaceType>>::SendMessageBuffer(
-                           &messageBuffer[0], 0, messageBuffer.size());
-                //return rc && mMountStateMachine.DoTransition(TelescopeSignals::GoTo);
+                std::cerr << "Sent Sync command!" << std::endl;       
+                if (true) {
+                    mCurrentPointingCoordinatesSyncCorrection.RightAscension=rightAscension-mCurrentPointingCoordinatesSyncBase.RightAscension;        
+                    mCurrentPointingCoordinatesSyncCorrection.Declination=declination-mCurrentPointingCoordinatesSyncBase.Declination;        
+                    return true;
+                }             
+                else {
+                    return SerialDeviceControl::SerialCommandTransceiver<InterfaceType, TelescopeMountControl::ExosIIMountControl<InterfaceType>>::SendMessageBuffer(
+                            &messageBuffer[0], 0, messageBuffer.size());
+                    //return rc && mMountStateMachine.DoTransition(TelescopeSignals::GoTo);
+                }
             }
             else
             {

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -338,11 +338,6 @@ class ExosIIMountControl :
             }
             else
             {
-                // align Sync Base when MotionToDirection ends
-                SerialDeviceControl::EquatorialCoordinates ec = mCurrentPointingCoordinates.Get();
-                mCurrentPointingCoordinatesSyncBase.RightAscension = ec.RightAscension - mCurrentPointingCoordinatesSyncCorrection.RightAscension;
-                mCurrentPointingCoordinatesSyncBase.Declination = ec.Declination - mCurrentPointingCoordinatesSyncCorrection.Declination;
-
                 return mMountStateMachine.DoTransition(TelescopeSignals::StopMotion);
             }
         }
@@ -707,6 +702,11 @@ class ExosIIMountControl :
                         }
                         else
                         {
+                            // align Sync Base while tracking: motions occurred, mount tracking not perfect
+                            SerialDeviceControl::EquatorialCoordinates ec = mCurrentPointingCoordinates.Get();
+                            mCurrentPointingCoordinatesSyncBase.RightAscension = ec.RightAscension - mCurrentPointingCoordinatesSyncCorrection.RightAscension;
+                            mCurrentPointingCoordinatesSyncBase.Declination = ec.Declination - mCurrentPointingCoordinatesSyncCorrection.Declination;
+
                             signal = TelescopeSignals::Track;
                         }
                     }

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -338,6 +338,11 @@ class ExosIIMountControl :
             }
             else
             {
+                // align Sync Base when MotionToDirection ends
+                SerialDeviceControl::EquatorialCoordinates ec = mCurrentPointingCoordinates.Get();
+                mCurrentPointingCoordinatesSyncBase.RightAscension=ec.RightAscension;
+                mCurrentPointingCoordinatesSyncBase.Declination=ec.Declination;
+
                 return mMountStateMachine.DoTransition(TelescopeSignals::StopMotion);
             }
         }

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -340,8 +340,8 @@ class ExosIIMountControl :
             {
                 // align Sync Base when MotionToDirection ends
                 SerialDeviceControl::EquatorialCoordinates ec = mCurrentPointingCoordinates.Get();
-                mCurrentPointingCoordinatesSyncBase.RightAscension=ec.RightAscension;
-                mCurrentPointingCoordinatesSyncBase.Declination=ec.Declination;
+                mCurrentPointingCoordinatesSyncBase.RightAscension = ec.RightAscension - mCurrentPointingCoordinatesSyncCorrection.RightAscension;
+                mCurrentPointingCoordinatesSyncBase.Declination = ec.Declination - mCurrentPointingCoordinatesSyncCorrection.Declination;
 
                 return mMountStateMachine.DoTransition(TelescopeSignals::StopMotion);
             }

--- a/ExosIIMountControl.hpp
+++ b/ExosIIMountControl.hpp
@@ -425,14 +425,15 @@ class ExosIIMountControl :
         {
             std::vector<uint8_t> messageBuffer;
             if(SerialDeviceControl::SerialCommand::GetSyncCommandMessage(messageBuffer, rightAscension, declination))
-            {
-                std::cerr << "Sent Sync command!" << std::endl;       
+            {                
                 if (true) {
+                    std::cerr << "Sent Sync command to coordinates correction!" << std::endl;       
                     mCurrentPointingCoordinatesSyncCorrection.RightAscension=rightAscension-mCurrentPointingCoordinatesSyncBase.RightAscension;        
                     mCurrentPointingCoordinatesSyncCorrection.Declination=declination-mCurrentPointingCoordinatesSyncBase.Declination;        
                     return true;
                 }             
                 else {
+                    std::cerr << "Sent Sync command to mount!" << std::endl;       
                     return SerialDeviceControl::SerialCommandTransceiver<InterfaceType, TelescopeMountControl::ExosIIMountControl<InterfaceType>>::SendMessageBuffer(
                             &messageBuffer[0], 0, messageBuffer.size());
                     //return rc && mMountStateMachine.DoTransition(TelescopeSignals::GoTo);

--- a/IndiSerialWrapper.cpp
+++ b/IndiSerialWrapper.cpp
@@ -78,7 +78,15 @@ int16_t IndiSerialWrapper::ReadByte()
         if(result == TTY_OK)
         {
             //std::cerr << "Read OK: FD " << std::dec << mTtyFd << " data: " << std::hex << dataByte << std::dec << std::endl;
-            return dataByte;
+            
+            //return dataByte;
+
+            /*
+            GCC defaults to signed char on x86 (which has 8-bit registers) and unsigned char on ARM which only has 32-bit registers and cannot easily do 8 bit signed arithmetic.
+            Use -funsigned-char or -fsigned-char to set your own default.             
+            */
+            return (uint8_t)dataByte; // safe cast to avoid negative values when -fsigned-char is used
+
         }
         /*else
         {


### PR DESCRIPTION
I saw (serial sniffer), at least with my Exos II mount, that ASCOM driver does not send commands to mount with SYNC function.

So, I managed the idea to change reported coordinates from driver comparing the position of the last GOTO (called Sync base coordinates) with that of the SYNC function (later), and moving coordinates accordingly.

Later I extended this behaviour to motion and than to tracking (mount tracks too fast or too lost) removing the one from motion (covered by the one in tracking)

KStars seems to behave well.

I'll try with a real night observation session, sooner
And also to do something with the handbox to see how it interacts.
For now the idea was to use only KStars
1 Goto
2 Some motions to align telescop, or even StellarSolver
3 Sync

If you believe that these integrations could be useful for your project, I'll feel glad to have contributed

Nice day
D. Fasoli